### PR TITLE
ci(github): fix build pr workflow

### DIFF
--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -10,5 +10,11 @@ on:
 
 jobs:
   build-pr:
+    if: |
+      startsWith(github.head_ref, '7.14.x') != 'true' ||
+      startsWith(github.head_ref, '7.15.x') != 'true' ||
+      startsWith(github.head_ref, '8.0.x') != 'true' ||
+      startsWith(github.head_ref, 'master') != 'true' ||
+      startsWith(github.head_ref, 'release-') != 'true'
     uses: ./.github/workflows/_reusable_build.yml
     secrets: inherit

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,10 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
+					<artifactId>maven-deploy-plugin</artifactId>
+					<version>3.1.1</version>
+				</plugin>
+				<plugin>
 					<artifactId>maven-assembly-plugin</artifactId>
 					<version>3.3.0</version>
 				</plugin>


### PR DESCRIPTION
- Upgrade maven-deploy-plugin to 3.1.1
- Execute build-pr workflow only if it is not on a base branch